### PR TITLE
Substitute in F# 3.1 for later versions

### DIFF
--- a/src/IfSharpConsole/App.config
+++ b/src/IfSharpConsole/App.config
@@ -12,7 +12,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.3.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
This allows some libs built against later FSharp.Core.dll to be
supported under IfSharp e.g. FAKE.
